### PR TITLE
Bumps fastjson from 1.2.76 to 1.2.83.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
       <dependency>
         <groupId>com.alibaba</groupId>
         <artifactId>fastjson</artifactId>
-        <version>1.2.76</version>
+        <version>1.2.83</version>
       </dependency>
       <!--quartz-->
       <dependency>


### PR DESCRIPTION
Bumps fastjson from 1.2.76 to 1.2.83.
To fix CVE-2022-25845:
The package com.alibaba:fastjson before 1.2.83 are vulnerable to Deserialization of Untrusted Data by bypassing the default autoType shutdown restrictions, which is possible under certain conditions. Exploiting this vulnerability allows attacking remote servers. Workaround: If upgrading is not possible, you can enable [safeMode]